### PR TITLE
Added the ability to exclude files

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const csso = require('csso');
 const rp = require('request-promise');
+const multimatch = require('multimatch');
 
 
 module.exports = options => {
@@ -20,6 +21,7 @@ module.exports = options => {
   let cssoOptions = options.cssoOptions || {};
   let defaultMedia = options.defaultMedia || 'screen';
   let removeLocalSrc = options.removeLocalSrc || false;
+  let exclude = options.exclude || [];
 
   return (files, metalsmith, done) => {
     let styles = {};
@@ -30,6 +32,11 @@ module.exports = options => {
     for (let file in files) {
       // parse only builded html files
       if (!file.endsWith('.html')) {
+        continue;
+      }
+
+      if (multimatch([file], exclude).length > 0) {
+        debug(`skipping excluded file ${file}`);
         continue;
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "metalsmith-css-packer",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -164,6 +164,14 @@
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
           "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         }
+      }
+    },
+    "debug": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
       }
     },
     "delayed-stream": {
@@ -460,6 +468,11 @@
       "requires": {
         "mime-db": "1.27.0"
       }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "nth-check": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "bluebird": "^3.5.0",
     "cheerio": "^0.22.0",
     "csso": "^3.1.1",
+    "debug": "^3.1.0",
+    "multimatch": "^2.1.0",
     "request": "^2.81.0",
     "request-promise": "^4.2.1"
   }


### PR DESCRIPTION
Pretty much like stafyniaksacha/metalsmith-js-packer#2

In this PR, I added the ability to exclude files from the build process. It uses multimatch for pattern matching. It basically adds the exclude attribute to the options object. The exclude attribute is an array of patterns in the form of minimatch (wildcards and globs are allowed).