### PR TITLE
WIP: Allow <style> contents only to be minified and inlined

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,6 @@ module.exports = options => {
             debug(`+-->  processing inline stylesheet identified by "${styleHash}"`);
 
             styles[media][styleHash] = $element.html();
-            return;
           }
 
           pageStyles[media].push(styleHash);


### PR DESCRIPTION
Use case: If only a <style> is present in <head>, no linked stylesheets and no inline style attributes, I want my css to be minified and left in <style> tag in head (inline:true plugin option).

Issue: CSS is not minified because css never gets added to pageStyles array, which is what becomes processed (minifed) and added inline if inline set to true. 

Solution: Remove return statement, to allow css to be added to pageStyles and processed. 

Needs: This is a WIP. It needs to be properly tested. Do you have any test scripts or projects to test this with? Or suggestions/gotchas when running this through use cases. 

Thanks,
Brittney