### PR TITLE
Add assets source path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,5 +133,7 @@ To blacklist element from packing, simply add `data-packer="exclude"` attribute 
 | `csso` | `true` | Enable/disable css optimizer |
 | `cssoOptions` | `{}` | Options passed to [csso](https://www.npmjs.com/package/csso#minifysource-options) |
 | `removeLocalSrc ` | `false` | If set to `true` local source files are not copied in build directory |
+| `assetsSource ` | `false` | Where to find your css files - this comes before the css file paths that are set in your .html file. If not set, it goes with default metalsmith source path `metalsmith._source`|
+
 
 > hint: metalsmith-css-packer use debug

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ To blacklist element from packing, simply add `data-packer="exclude"` attribute 
 | `csso` | `true` | Enable/disable css optimizer |
 | `cssoOptions` | `{}` | Options passed to [csso](https://www.npmjs.com/package/csso#minifysource-options) |
 | `removeLocalSrc ` | `false` | If set to `true` local source files are not copied in build directory |
-| `assetsSource ` | metalsmith config `source` | Where to find your css files - this comes before the css file paths that are set in your .html file. If not set, it goes with default metalsmith source path `metalsmith._source`|
+| `assetsSource ` | `source` from metalsmith config | Where to find your css files - this comes before the css file paths that are set in your .html file. If not set, it goes with default metalsmith source path `metalsmith._source`|
 
 
 > hint: metalsmith-css-packer use debug

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ To blacklist element from packing, simply add `data-packer="exclude"` attribute 
 | `csso` | `true` | Enable/disable css optimizer |
 | `cssoOptions` | `{}` | Options passed to [csso](https://www.npmjs.com/package/csso#minifysource-options) |
 | `removeLocalSrc ` | `false` | If set to `true` local source files are not copied in build directory |
-| `assetsSource ` | `false` | Where to find your css files - this comes before the css file paths that are set in your .html file. If not set, it goes with default metalsmith source path `metalsmith._source`|
+| `assetsSource ` | metalsmith config `source` | Where to find your css files - this comes before the css file paths that are set in your .html file. If not set, it goes with default metalsmith source path `metalsmith._source`|
 
 
 > hint: metalsmith-css-packer use debug

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const debug = require('debug')('metalsmith-css-packer')
-const Bluebird  = require('bluebird');
+const Bluebird = require('bluebird');
 const cheerio = require('cheerio');
 const crypto = require('crypto');
 const fs = require('fs');
@@ -20,6 +20,8 @@ module.exports = options => {
   let cssoOptions = options.cssoOptions || {};
   let defaultMedia = options.defaultMedia || 'screen';
   let removeLocalSrc = options.removeLocalSrc || false;
+  let assetsSource = options.assetsSource || false;
+
 
   return (files, metalsmith, done) => {
     let styles = {};
@@ -102,7 +104,7 @@ module.exports = options => {
               debug(`+-->  processing local stylesheet located at "${href}"`);
 
               // TODO: check with generated css with sass / less
-              let stylePath = path.join(metalsmith._directory, metalsmith._source, href)
+              let stylePath = path.join(metalsmith._directory, assetsSource ? assetsSource : metalsmith._source, href)
 
               if (!fs.existsSync(stylePath)) {
                 if (files[href.substring(1)] === undefined) {
@@ -171,6 +173,7 @@ module.exports = options => {
             debug(`+-->  processing inline stylesheet identified by "${styleHash}"`);
 
             styles[media][styleHash] = $element.html();
+            return;
           }
 
           pageStyles[media].push(styleHash);
@@ -223,7 +226,7 @@ module.exports = options => {
     // we can pack all styles togethers once all pending remotes styles are fetched
     Bluebird.all(remoteStylesPromises)
       .then(() => {
-        for(let pageStylesHash in packedStyles) {
+        for (let pageStylesHash in packedStyles) {
           debug(`create packed stylesheet "${pageStylesHash}", used by ${packedStylesUsage[pageStylesHash].length} files`);
 
           let packedStyle = '';


### PR DESCRIPTION
Currently, `metalsmith-css-packer` takes config source path when looking for the css files within `.html` files. This pull request enables `assetsSource` option that permits the user to specify a different source path.