### PR TITLE
Add hashContent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,5 +133,6 @@ To blacklist element from packing, simply add `data-packer="exclude"` attribute 
 | `csso` | `true` | Enable/disable css optimizer |
 | `cssoOptions` | `{}` | Options passed to [csso](https://www.npmjs.com/package/csso#minifysource-options) |
 | `removeLocalSrc ` | `false` | If set to `true` local source files are not copied in build directory |
+| `hashContent` | `false` | If set to `false`, output file name are a hash of all input style names. If set to `true`, output file names are a hash of the resulting style contents. Useful for serving stylesheets with an efficient cache policy. |
 
 > hint: metalsmith-css-packer use debug

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ module.exports = options => {
   let cssoOptions = options.cssoOptions || {};
   let defaultMedia = options.defaultMedia || 'screen';
   let removeLocalSrc = options.removeLocalSrc || false;
+  let hashContent = options.hashContent || false;
 
   return (files, metalsmith, done) => {
     let styles = {};
@@ -204,11 +205,6 @@ module.exports = options => {
           packedStylesUsage[pageStylesHash].push(file);
 
           debug(`register usage of packed style "${pageStylesHash}" (media: "${media}") for file "${file}"`);
-
-          // include style reference only when inline mode is disabled
-          if (!inline) {
-            $('<link>').attr('media', media).attr('rel', 'stylesheet').attr('href', siteRootPath + outputPath + pageStylesHash + '.min.css').appendTo('head');
-          }
         }
       }
 
@@ -236,13 +232,32 @@ module.exports = options => {
             packedStyle = csso.minify(packedStyle, cssoOptions).css;
           }
 
-          // include style reference only when inline mode is enabled
-          // else, add new packed file to metalsmith file list
-          if (!inline) {
-            debug(`write packed stylesheet "${pageStylesHash}" in "${outputPath + pageStylesHash + '.min.css'}" file`);
+          let finalHash;
+          if (hashContent) {
+            finalHash = crypto.createHash('sha1').update(packedStyle).digest('hex');
+            debug(`mapping hash "${pageStylesHash}" to content hash "${finalHash}"`);
+          } else {
+            finalHash = pageStylesHash;
+          }
 
-            files[outputPath + pageStylesHash + '.min.css'] = {
+          // include style reference only when inline mode is enabled
+          // else, add new packed file to metalsmith file list and
+          // link it
+          if (!inline) {
+            debug(`write packed stylesheet "${pageStylesHash}" in "${outputPath + finalHash + '.min.css'}" file`);
+
+            files[outputPath + finalHash + '.min.css'] = {
               contents: Buffer.from(packedStyle, 'utf-8')
+            };
+
+            for (let file of packedStylesUsage[pageStylesHash]) {
+              debug(`link packed stylesheet "${finalHash}" in "${file}" file`);
+
+              let $ = cheerio.load(files[file].contents.toString());
+
+              $('<link>').attr('media', packedStyles[pageStylesHash].media).attr('rel', 'stylesheet').attr('href', siteRootPath + outputPath + finalHash + '.min.css').appendTo('head');
+
+              files[file].contents = Buffer.from($.html(), 'utf-8');
             }
           }
           else {


### PR DESCRIPTION
This option uses final packed stylesheet content hash as stylesheet
file name. Useful for serving stylesheets with an efficient cache
policy.

I've made it `false` by default to preserve old behavior. However, it is really useful and I don't see any drawbacks, so it might be good to make it enabled by default.